### PR TITLE
96 recode list

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 ## New features
 
+* `recode_only()`, and `recode_by()` now accept a named `list()` for `by` [#96](https://github.com/jmbarbone/mark/issues/96)]
 * `switch_in_case()` now handles functions in rhs
 * `update_version()` now correctly checks result of embedded `utils::menu()` call for updating the version [#123](https://github.com/jmbarbone/mark/issues/121)
 * `require_namespace()` now accepts multiple namespaces [#121](https://github.com/jmbarbone/mark/issues/121)

--- a/R/recode.R
+++ b/R/recode.R
@@ -30,6 +30,9 @@
 #' recode_only(letters[1:3], c(`1` = "a")) # returns as "1"
 #' recode_only(1:3, c("a" = 1))            # coerced to NA
 #'
+#' # Pass list for multiples
+#' recode_only(letters[1:10], list(abc = c("a", "b", "c"), ef = c("e", "f")))
+#'
 #' @seealso [dplyr::recode()]
 #' @export
 
@@ -38,6 +41,10 @@ recode_by <- function(x, by, vals = NULL, mode = "any") {
   if (is.factor(x)) {
     levels(x) <- recode_by(levels(x), by = by, vals = vals, mode = mode)
     return(x)
+  }
+
+  if (is.list(by)) {
+    by <- unlist0(by)
   }
 
   vals <- vals %||% names(by)
@@ -62,10 +69,18 @@ recode_only <- function(x, by, vals = NULL) {
     return(x)
   }
 
+  if (is.list(by)) {
+    by <- unlist0(by)
+  }
+
   vals <- vals %||% names(by)
 
   if (is.null(vals)) {
     stop("values to recode by were not properly set", call. = FALSE)
+  }
+
+  if (is.list(vals)) {
+    vals <- unlist0
   }
 
   vals <- as.vector(vals, if (typeof(x) == "integer") "integer" else mode(x))

--- a/man/recode_by.Rd
+++ b/man/recode_by.Rd
@@ -46,6 +46,9 @@ recode_only(letters[1:3], c("zzz" = "a"))
 recode_only(letters[1:3], c(`1` = "a")) # returns as "1"
 recode_only(1:3, c("a" = 1))            # coerced to NA
 
+# Pass list for multiples
+recode_only(letters[1:10], list(abc = c("a", "b", "c"), ef = c("e", "f")))
+
 }
 \seealso{
 \code{\link[dplyr:recode]{dplyr::recode()}}

--- a/tests/testthat/test-recode.R
+++ b/tests/testthat/test-recode.R
@@ -69,3 +69,16 @@ test_that("factors", {
   exp <- factor(c("A", NA, NA))
   expect_identical(res, exp)
 })
+
+test_that("recode_*(by = list())", {
+  x <- c("a", "b", "c", "d", "e")
+  by <- list(xy = c("a", "b"), z = "d")
+
+  exp <- c("xy", "xy", "c", "z", "e")
+  res <- recode_only(x, by)
+  expect_identical(exp, res)
+
+  exp <- c("xy", "xy", NA, "z", NA)
+  res <- recode_by(x, by)
+  expect_identical(exp, res)
+})


### PR DESCRIPTION
Resolves #96.

makes `recode_*(by = list())` valid

- allow list in by resolves #96
- redoc
- add tests
- updates news
